### PR TITLE
Respawnable conductors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/try-o-rama",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,7 +1,9 @@
 import {Waiter} from '@holochain/hachiko'
 
 import {delay} from './util'
+import * as T from './types'
 import {ConductorMap, ScenarioInstanceRef} from './instance'
+import {ConductorFactory} from './conductor-factory'
 
 export class ScenarioApi {
 
@@ -21,20 +23,28 @@ export class ScenarioApi {
     })
   })
 
-  start = (...instances: Array<ScenarioInstanceRef | string>) => {
-    return Promise.all(
-      instances.map(inst => this.callAdmin('admin/instance/start')({
-        id: typeof inst === 'string' ? inst : inst.id
-      }))
-    )
-  }
+  spawn = (factories: Array<ConductorFactory>) => Promise.all(
+    factories.map(f => f.spawn())
+  )
 
-  stop = (...instances: Array<ScenarioInstanceRef | string>) => {
-    return Promise.all(
-      instances.map(inst => this.callAdmin('admin/instance/stop')({
-        id: typeof inst === 'string' ? inst : inst.id
-      }))
-    )
-  }
+  kill = (factories: Array<ConductorFactory>) => Promise.all(
+    factories.map(f => f.kill())
+  )
+
+  // start = (...instances: Array<ScenarioInstanceRef | string>) => {
+  //   return Promise.all(
+  //     instances.map(inst => this.callAdmin('admin/instance/start')({
+  //       id: typeof inst === 'string' ? inst : inst.id
+  //     }))
+  //   )
+  // }
+
+  // stop = (...instances: Array<ScenarioInstanceRef | string>) => {
+  //   return Promise.all(
+  //     instances.map(inst => this.callAdmin('admin/instance/stop')({
+  //       id: typeof inst === 'string' ? inst : inst.id
+  //     }))
+  //   )
+  // }
 
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,39 +1,39 @@
 import {Waiter} from '@holochain/hachiko'
 
-import {delay} from './util'
+import {delay, trace} from './util'
 import * as T from './types'
 import {ConductorMap, ScenarioInstanceRef} from './instance'
 import {ConductorFactory} from './conductor-factory'
 
 export class ScenarioApi {
 
-  waiter: Waiter
-  callAdmin: any
+  _waiter: Waiter
+  _callAdmin: any
 
   constructor (waiter: Waiter, callAdmin: any) {
-    this.waiter = waiter
-    this.callAdmin = callAdmin
+    this._waiter = waiter
+    this._callAdmin = callAdmin
   }
 
   consistent = (instances?) => new Promise((resolve, reject) => {
-    this.waiter.registerCallback({
+    this._waiter.registerCallback({
       nodes: instances ? instances.map(i => i.id) : null,
       resolve,
       reject,
     })
   })
 
-  spawn = (factories: Array<ConductorFactory>) => Promise.all(
+  spawn = (...factories: Array<ConductorFactory>) => Promise.all(
     factories.map(f => f.spawn())
   )
 
-  kill = (factories: Array<ConductorFactory>) => Promise.all(
+  kill = (...factories: Array<ConductorFactory>) => Promise.all(
     factories.map(f => f.kill())
   )
 
   // start = (...instances: Array<ScenarioInstanceRef | string>) => {
   //   return Promise.all(
-  //     instances.map(inst => this.callAdmin('admin/instance/start')({
+  //     instances.map(inst => this._callAdmin('admin/instance/start')({
   //       id: typeof inst === 'string' ? inst : inst.id
   //     }))
   //   )
@@ -41,7 +41,7 @@ export class ScenarioApi {
 
   // stop = (...instances: Array<ScenarioInstanceRef | string>) => {
   //   return Promise.all(
-  //     instances.map(inst => this.callAdmin('admin/instance/stop')({
+  //     instances.map(inst => this._callAdmin('admin/instance/stop')({
   //       id: typeof inst === 'string' ? inst : inst.id
   //     }))
   //   )

--- a/src/conductor-definition.ts
+++ b/src/conductor-definition.ts
@@ -1,0 +1,9 @@
+
+
+const ADMIN_INTERFACE_ID = 'admin-interface'
+
+
+export class ConductorDefinition {
+  configPath: string
+  adminPort: number
+}

--- a/src/conductor-definition.ts
+++ b/src/conductor-definition.ts
@@ -1,9 +1,0 @@
-
-
-const ADMIN_INTERFACE_ID = 'admin-interface'
-
-
-export class ConductorDefinition {
-  configPath: string
-  adminPort: number
-}

--- a/src/conductor-external.ts
+++ b/src/conductor-external.ts
@@ -1,0 +1,67 @@
+const child_process = require('child_process')
+const del = require('del')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const getPort = require('get-port')
+
+const colors = require('colors/safe')
+
+const _ = require('lodash')
+
+import {Signal} from '@holochain/hachiko'
+import {promiseSerial, delay} from './util'
+import * as T from './types'
+import {ScenarioInstanceRef, InstanceMap} from './instance'
+import {Conductor} from './conductor'
+import logger from './logger'
+
+/// //////////////////////////////////////////////////////////
+
+// these should be already set when the conductor is started by `hc test`
+const wsUrl = port => `ws://localhost:${port}`
+
+const DEFAULT_ZOME_CALL_TIMEOUT = 60000
+
+type ConductorOpts = {
+  onSignal: (Signal) => void,
+  zomeCallTimeout?: number,
+  name: string,
+  adminInterfaceUrl: string,
+  configPath
+}
+
+const storagePath = () => process.env.TRYORAMA_STORAGE || fs.mkdtempSync(path.join(os.tmpdir(), 'try-o-rama-'))
+
+/**
+ * Represents a conductor process to which calls can be made via RPC
+ */
+export class ConductorExternal extends Conductor {
+
+  webClientConnect: any
+  agentIds: Set<string>
+  dnaIds: Set<string>
+  instanceMap: InstanceMap
+  opts: any
+  name: string
+  adminInterfaceUrl: string
+  handle: any
+  onSignal: (any) => void
+
+  runningInstances: Array<T.InstanceConfig>
+  testPort: number
+  adminPort: number
+
+  isInitialized: boolean
+
+
+  abort (msg) {
+    logger.error(`Test conductor aborted: %j`, msg)
+    process.exit(-1)
+  }
+
+  failTest (e) {
+    logger.error("Test failed while running: %j", e)
+    throw e
+  }
+}

--- a/src/conductor-external.ts
+++ b/src/conductor-external.ts
@@ -56,12 +56,8 @@ export class ConductorExternal extends Conductor {
 
 
   abort (msg) {
-    logger.error(`Test conductor aborted: %j`, msg)
+    logger.error(`Test conductor aborted: %o`, msg)
     process.exit(-1)
   }
 
-  failTest (e) {
-    logger.error("Test failed while running: %j", e)
-    throw e
-  }
 }

--- a/src/conductor-factory.ts
+++ b/src/conductor-factory.ts
@@ -130,6 +130,8 @@ export class ConductorFactory implements ScenarioConductor {
       if (this.conductor) {
         await this.conductor.cleanupRun(this.testConfig)
         await this.kill()
+      } else {
+        logger.debug("factory cleaned up, but there was no conductor 🤔")
       }
     } catch (e) {
       console.error("Caught something during factory cleanup:")

--- a/src/conductor-factory.ts
+++ b/src/conductor-factory.ts
@@ -1,0 +1,90 @@
+/**
+ * ConductorFactory:
+ * The class representing
+ */
+
+import {ConductorManaged} from './conductor-managed'
+import * as T from './types'
+
+const ADMIN_INTERFACE_ID = 'admin-interface'
+
+
+export interface ScenarioConductor {
+  name: string
+  spawn ()
+  kill ()
+}
+
+type ConstructorArgs = {
+  spawnConductor: T.SpawnConductorFn,
+  genConfig: T.GenConfigFn,
+  testConfig: T.ConductorConfig
+}
+
+export class ConductorFactory implements ScenarioConductor {
+  name: string
+  configData: T.GenConfigReturn | null
+  conductor: ConductorManaged | null
+  spawnConductor: T.SpawnConductorFn
+  genConfig: T.GenConfigFn
+  testConfig: T.ConductorConfig
+  firstSpawn: boolean  // Each test starts with firstSpawn === true
+
+  constructor (args: ConstructorArgs) {
+    const {
+      spawnConductor,
+      genConfig,
+      testConfig
+    } = args
+    this.spawnConductor = spawnConductor
+    this.genConfig = genConfig
+    this.testConfig = testConfig
+    this.firstSpawn = true
+  }
+
+  async spawn () {
+    if (!this.configData) {
+      throw new Error(`Attempted to spawn conductor '${this.name}' before config was generated`)
+    } else if (this.conductor) {
+      throw new Error(`Attempted to spawn conductor '${this.name}' twice`)
+    }
+    this.conductor = await this.spawnConductor(this.configData.configPath)
+    if (this.firstSpawn) {
+      await this.conductor.prepareRun(this.testConfig)
+      this.firstSpawn = false
+    }
+  }
+
+  async kill () {
+    if (!this.conductor) {
+      throw new Error(`Attempted to kill conductor '${this.name}' before spawning`)
+    }
+    await this.conductor.kill()
+    this.conductor = null
+  }
+
+  async setup () {
+    this.configData = this.genConfig(true)
+  }
+
+  async cleanup () {
+    try {
+      await this.conductor!.cleanupRun(this.testConfig)
+      await this.kill()
+    } catch (e) {}
+    this.configData = null
+  }
+}
+
+export const conductorFactoryProxy = original => new Proxy(original, {
+  get (factory, name) {
+    if (!factory.conductor) {
+      throw new Error("No conductor running.")
+    }
+    if (!(name in factory)) {
+      return factory.conductor.instanceMap[name]
+    } else {
+      return factory[name]
+    }
+  }
+})

--- a/src/conductor-factory.ts
+++ b/src/conductor-factory.ts
@@ -93,6 +93,8 @@ export class ConductorFactory implements ScenarioConductor {
       this.conductor = this.lastConductor!
       this.conductor.handle = handle
       this.lastConductor = null
+      logger.debug("ConductorFactory :: spawn :: spawned")
+      await this.conductor.initialize()
     }
     await this.conductor.makeConnections(this.testConfig)
     if (this.firstSpawn) {
@@ -125,8 +127,10 @@ export class ConductorFactory implements ScenarioConductor {
 
   async cleanup () {
     try {
-      await this.conductor!.cleanupRun(this.testConfig)
-      await this.kill()
+      if (this.conductor) {
+        await this.conductor.cleanupRun(this.testConfig)
+        await this.kill()
+      }
     } catch (e) {
       console.error("Caught something during factory cleanup:")
       console.error(e)

--- a/src/conductor-managed.ts
+++ b/src/conductor-managed.ts
@@ -1,0 +1,71 @@
+const child_process = require('child_process')
+const del = require('del')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const getPort = require('get-port')
+
+const colors = require('colors/safe')
+
+const _ = require('lodash')
+
+import {Signal} from '@holochain/hachiko'
+import {promiseSerial, delay} from './util'
+import * as T from './types'
+import {ScenarioInstanceRef, InstanceMap} from './instance'
+import {Conductor} from './conductor'
+import logger from './logger'
+
+/// //////////////////////////////////////////////////////////
+
+// these should be already set when the conductor is started by `hc test`
+const wsUrl = port => `ws://localhost:${port}`
+
+const DEFAULT_ZOME_CALL_TIMEOUT = 60000
+
+type ConductorOpts = {
+  onSignal: (Signal) => void,
+  zomeCallTimeout?: number,
+  name: string,
+  adminInterfaceUrl: string,
+  configPath
+}
+
+const storagePath = () => process.env.TRYORAMA_STORAGE || fs.mkdtempSync(path.join(os.tmpdir(), 'try-o-rama-'))
+
+/**
+ * Represents a conductor process to which calls can be made via RPC
+ *
+ * @class      Conductor (name)
+ */
+export class ConductorManaged extends Conductor {
+
+  webClientConnect: any
+  agentIds: Set<string>
+  dnaIds: Set<string>
+  instanceMap: InstanceMap
+  opts: any
+  name: string
+  adminInterfaceUrl: string
+  handle: any
+  dnaNonce: number
+  onSignal: (any) => void
+
+  runningInstances: Array<T.InstanceConfig>
+  testPort: number
+  adminPort: number
+
+  isInitialized: boolean
+
+
+  kill () {
+    logger.info("TODO: kill?")
+  }
+
+  abort (msg) {
+    logger.error(`Test conductor aborted: %j`, msg)
+    this.kill()
+    process.exit(-1)
+  }
+
+}

--- a/src/conductor-managed.ts
+++ b/src/conductor-managed.ts
@@ -45,7 +45,7 @@ export class ConductorManaged extends Conductor {
   }
 
   async abort (msg) {
-    logger.error(`Test conductor aborted: %j`, msg)
+    logger.error(`Test conductor aborted: %o`, msg)
     await this.kill()
     process.exit(-1)
   }

--- a/src/conductor-managed.ts
+++ b/src/conductor-managed.ts
@@ -41,7 +41,9 @@ const storagePath = () => process.env.TRYORAMA_STORAGE || fs.mkdtempSync(path.jo
 export class ConductorManaged extends Conductor {
 
   kill () {
-    return this.handle.kill()
+    const signal = 'SIGINT'
+    logger.info(`Stopping conductor with ${signal}`)
+    return this.handle.kill(signal)
   }
 
   async abort (msg) {

--- a/src/conductor-managed.ts
+++ b/src/conductor-managed.ts
@@ -43,6 +43,7 @@ export class ConductorManaged extends Conductor {
   kill () {
     const signal = 'SIGINT'
     logger.info(`Stopping conductor with ${signal}`)
+    this.isInitialized = false
     return this.handle.kill(signal)
   }
 

--- a/src/conductor-managed.ts
+++ b/src/conductor-managed.ts
@@ -40,31 +40,13 @@ const storagePath = () => process.env.TRYORAMA_STORAGE || fs.mkdtempSync(path.jo
  */
 export class ConductorManaged extends Conductor {
 
-  webClientConnect: any
-  agentIds: Set<string>
-  dnaIds: Set<string>
-  instanceMap: InstanceMap
-  opts: any
-  name: string
-  adminInterfaceUrl: string
-  handle: any
-  dnaNonce: number
-  onSignal: (any) => void
-
-  runningInstances: Array<T.InstanceConfig>
-  testPort: number
-  adminPort: number
-
-  isInitialized: boolean
-
-
   kill () {
-    logger.info("TODO: kill?")
+    return this.handle.kill()
   }
 
-  abort (msg) {
+  async abort (msg) {
     logger.error(`Test conductor aborted: %j`, msg)
-    this.kill()
+    await this.kill()
     process.exit(-1)
   }
 

--- a/src/conductor.ts
+++ b/src/conductor.ts
@@ -23,7 +23,6 @@ const wsUrl = port => `ws://localhost:${port}`
 const DEFAULT_ZOME_CALL_TIMEOUT = 60000
 
 type ConductorOpts = {
-  onSignal: (Signal) => void,
   zomeCallTimeout?: number,
   name: string,
   adminInterfaceUrl: string,
@@ -32,23 +31,18 @@ type ConductorOpts = {
 
 const storagePath = () => process.env.TRYORAMA_STORAGE || fs.mkdtempSync(path.join(os.tmpdir(), 'try-o-rama-'))
 
-/**
- * Represents a conductor process to which calls can be made via RPC
- *
- * @class      Conductor (name)
- */
 export class Conductor {
 
   webClientConnect: any
   agentIds: Set<string>
   dnaIds: Set<string>
   instanceMap: InstanceMap
-  opts: any
+  opts: ConductorOpts
   name: string
   adminInterfaceUrl: string
   handle: any
   dnaNonce: number
-  onSignal: (any) => void
+  onSignal: (Signal) => void
 
   runningInstances: Array<T.InstanceConfig>
   testPort: number
@@ -291,7 +285,7 @@ export class Conductor {
     }
   }
 
-  prepareRun = async ({instances, bridges}: T.ConductorConfig) => {
+  async prepareRun ({instances, bridges}: T.ConductorConfig) {
     logger.debug(colors.yellow.bold("---------------------------------------------------------"))
     logger.debug(colors.yellow.bold(`-------  preparing ${this.name}`))
     logger.debug('')
@@ -338,18 +332,5 @@ export class Conductor {
     this.dnaNonce += 1
   }
 
-  kill () {
-    logger.info("TODO: kill?")
-  }
-
-  abort (msg) {
-    logger.error(`Test conductor aborted: %j`, msg)
-    this.kill()
-    process.exit(-1)
-  }
-
-  failTest (e) {
-    logger.error("Test failed while running: %j", e)
-    throw e
-  }
+  abort (msg: string)
 }

--- a/src/conductor.ts
+++ b/src/conductor.ts
@@ -270,8 +270,8 @@ export class Conductor {
     }
   }
 
-  startInstances = async (instanceConfigs: Array<T.InstanceConfig>) => {
-    for (const instanceConfig of instanceConfigs) {
+  startInstances = async ({instances}: T.ConductorConfig) => {
+    for (const instanceConfig of instances) {
       const instance = JSON.parse(JSON.stringify(instanceConfig))
       instance.id += '-' + this.dnaNonce
       await this.callAdmin('admin/instance/start')(instance)
@@ -311,8 +311,6 @@ export class Conductor {
     await this.connectTest()
     logger.debug("makeConnections :: connectSignals")
     await this.connectSignals()
-    logger.debug("makeConnections :: startInstances")
-    await this.startInstances(instances)
   }
 
   cleanupRun = async ({bridges}: T.ConductorConfig) => {

--- a/src/conductor.ts
+++ b/src/conductor.ts
@@ -22,11 +22,15 @@ const wsUrl = port => `ws://localhost:${port}`
 
 const DEFAULT_ZOME_CALL_TIMEOUT = 60000
 
+
+// TODO: is this just constructor args? or actually options for the conductor?
 type ConductorOpts = {
   zomeCallTimeout?: number,
   name: string,
   adminInterfaceUrl: string,
-  configPath
+  onSignal: (Signal) => void,
+  configPath: string,
+  handle: T.Mortal,
 }
 
 const storagePath = () => process.env.TRYORAMA_STORAGE || fs.mkdtempSync(path.join(os.tmpdir(), 'try-o-rama-'))
@@ -40,7 +44,7 @@ export class Conductor {
   opts: ConductorOpts
   name: string
   adminInterfaceUrl: string
-  handle: any
+  handle: T.Mortal
   dnaNonce: number
   onSignal: (Signal) => void
 
@@ -50,13 +54,13 @@ export class Conductor {
 
   isInitialized: boolean
 
-  constructor (connect, opts: ConductorOpts) {
-    this.webClientConnect = connect
+  constructor (opts: ConductorOpts) {
+    this.webClientConnect = 'TODO'
     this.agentIds = new Set()
     this.dnaIds = new Set()
     this.instanceMap = {}
     this.opts = opts
-    this.handle = null
+    this.handle = opts.handle
     this.runningInstances = []
     this.dnaNonce = 1
     this.onSignal = opts.onSignal
@@ -332,5 +336,8 @@ export class Conductor {
     this.dnaNonce += 1
   }
 
-  abort (msg: string)
+  abort (msg) {
+    logger.error(`Test conductor aborted: %j`, msg)
+    process.exit(-1)
+  }
 }

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -9,7 +9,7 @@ export class ScenarioInstanceRef {
   id: string
   agentAddress: string | null
   dnaAddress: string | null
-  callAdmin: any
+  callAdmin: any  // TODO: remove
   callZome: any
   signals: Array<any>
 

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -6,6 +6,7 @@ import {Conductor} from './conductor'
 
 export class ScenarioInstanceRef {
 
+  _conductor: Conductor
   id: string
   agentAddress: string | null
   dnaAddress: string | null
@@ -13,18 +14,17 @@ export class ScenarioInstanceRef {
   callZome: any
   signals: Array<any>
 
-  constructor ({instanceId, callZome, callAdmin}) {
+  constructor ({instanceId, conductor}) {
+    this._conductor = conductor
     this.id = instanceId
     this.agentAddress = null
     this.dnaAddress = null
-    this.callAdmin = callAdmin
-    this.callZome = callZome
     this.signals = []  // gets populated by onSignal via Conductor.connectSignals
   }
 
   // internally calls `this.conductor.call`
   async call (zome, fn, params) {
-    const result = await this.callZome(this.id, zome, fn)(params)
+    const result = await this._conductor.callZome(this.id, zome, fn)(params)
     logger.debug(colors.blue.inverse("zome call"), {id: this.id, zome, fn, params})
     try {
       return JSON.parse(result)

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,7 +1,7 @@
 import {createLogger, format, transports} from 'winston'
 import {NullTransport} from 'winston-null'
 
-const logLevel = 'info'
+const logLevel = 'debug'
 
 const logger = createLogger({
   levels: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,5 +58,5 @@ export type GenConfigReturn = {
 }
 
 export interface Mortal {
-  kill(): Promise<void>
+  kill(signal?): Promise<void>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 
 import {ScenarioApi} from './api'
 import {ScenarioInstanceRef} from './instance'
+import {ConductorManaged} from './conductor-managed'
 
 export type ScenarioFnCustom = (s: object, ins: {[id: string]: any}) => Promise<any>
 export type ScenarioFn = (s: ScenarioApi, ins: {[id: string]: ScenarioInstanceRef}) => Promise<any>
@@ -47,3 +48,11 @@ export type BridgeConfig = {
 
 export type ObjectN<V> = {[name: number]: V}
 export type ObjectS<V> = {[name: string]: V}
+
+export type SpawnConductorFn = (configPath: string) => ConductorManaged
+export type GenConfigFn = (debug: boolean) => GenConfigReturn
+
+export type GenConfigReturn = {
+  configPath: string,
+  adminPort: number,
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,7 @@ export type BridgeConfig = {
 export type ObjectN<V> = {[name: number]: V}
 export type ObjectS<V> = {[name: string]: V}
 
-export type GenConfigFn = (debug: boolean) => Promise<GenConfigReturn>
+export type GenConfigFn = (debug: boolean, index: number) => Promise<GenConfigReturn>
 export type SpawnConductorFn = (name: string, configPath: string) => Promise<Mortal>
 
 export type GenConfigReturn = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-
+import {ChildProcess} from 'child_process'
 import {ScenarioApi} from './api'
 import {ScenarioInstanceRef} from './instance'
 import {ConductorManaged} from './conductor-managed'
@@ -49,10 +49,14 @@ export type BridgeConfig = {
 export type ObjectN<V> = {[name: number]: V}
 export type ObjectS<V> = {[name: string]: V}
 
-export type SpawnConductorFn = (configPath: string) => ConductorManaged
-export type GenConfigFn = (debug: boolean) => GenConfigReturn
+export type GenConfigFn = (debug: boolean) => Promise<GenConfigReturn>
+export type SpawnConductorFn = (name: string, configPath: string) => Promise<Mortal>
 
 export type GenConfigReturn = {
   configPath: string,
-  adminPort: number,
+  adminUrl: string,
+}
+
+export interface Mortal {
+  kill(): Promise<void>
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -9,3 +9,9 @@ export const promiseSerial = promises =>
     promise.then(result =>
       p.then(Array.prototype.concat.bind(result))),
       Promise.resolve([]))
+
+
+export const trace = (msg, x) => {
+  console.log('<T>', msg, x)
+  return x
+}

--- a/test/common.ts
+++ b/test/common.ts
@@ -1,0 +1,5 @@
+
+import * as T from '../src/types'
+
+export const genConfig = (() => {}) as unknown as T.GenConfigFn
+export const spawnConductor = (() => {}) as unknown as T.SpawnConductorFn

--- a/test/test-executor.ts
+++ b/test/test-executor.ts
@@ -1,11 +1,14 @@
 import {Orchestrator, simpleExecutor} from '../src'
 
 import * as test from 'tape'
+import * as T from '../src/types'
 
 test("end to end, sort of", async t => {
   const orchestrator = new Orchestrator({
     conductors: {},
-    executor: simpleExecutor
+    executor: simpleExecutor,
+    genConfig: (() => {}) as unknown as T.GenConfigFn,
+    spawnConductor: (() => {}) as unknown as T.SpawnConductorFn,
   })
   orchestrator.runScenario = async scenario => scenario('s', 'ins')
   orchestrator.registerScenario('description', async (s, ins) => {

--- a/test/test-orchestrator.ts
+++ b/test/test-orchestrator.ts
@@ -2,6 +2,8 @@ import {simpleExecutor} from '../src/executors'
 import {OrchestratorClass} from '../src/orchestrator'
 import * as test from 'tape'
 
+import {genConfig, spawnConductor} from './common'
+
 const http = require('http')
 
 test('a', async t => {
@@ -63,8 +65,9 @@ test('a', async t => {
         ],
       },
     },
-
     debugLog: false,
+    genConfig,
+    spawnConductor,
   })
 
   t.equal(Object.keys(orchestrator.conductorConfigs).length, 2)
@@ -109,7 +112,8 @@ test('callbacks', async t => {
       },
     },
     debugLog: false,
-    callbacksPort: 4242
+    genConfig,
+    spawnConductor,
   })
 
   console.warn("TODO: reinstate a test that actually runs the orchestrator")

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,6 @@
   ],
   "exclude": [
     "node_modules",
-    "lib",
-    "src/__tests__"
+    "lib"
   ]
 }


### PR DESCRIPTION
Some major changes:

- Adds ScenarioApi `spawn` and `kill`
- Adds `ConductorFactory` to represent an object that refers to 0 or 1 conductors, and can spawn and kill that reference arbitrarily
- Separates `spawnConductor` into `genConfig` and `spawnConductor`
- Middleware is broken
- `alice.app.call` syntax is broken. Adding sugar to this will be complicated.